### PR TITLE
Implement Delegatecall and Refactor ContractLib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file.
 - *(EventLib)* Add anonymous event emitters
 - *(ContractLib)* Add library functions
 - *(ContractLib)* Add missing function bodies
+- *(ContractLib)* Implement staticcall
+- *(ContractLib)* Implement delegatecall
 
 ### 🐛 Bug Fixes
 
@@ -35,6 +37,9 @@ All notable changes to this project will be documented in this file.
 - *(ContractLib)* Partially broken code
 - *(ContractLib)* Add custom errors
 - *(ContractLib)* Add custom error
+- *(ContractLib)* Merge call functions
+- Add mock contract
+- *(ContractLib.t.sol)* Implement mock contract
 
 ### 🎨 Styling
 
@@ -56,6 +61,8 @@ All notable changes to this project will be documented in this file.
 - *(ContactLib)* Finish positive cases
 - *(ContractLib)* Update test cases
 - *(ContractLib)* Update test cases
+- *(ContractLib)* Add staticcall test cases
+- *(ContractLib)* Test new call functions
 
 ### ⚙️ Miscellaneous Tasks
 
@@ -67,6 +74,7 @@ All notable changes to this project will be documented in this file.
 - Update Gasgnome.sol
 - Update CHANGELOG.md
 - Update Gasgnome.sol
+- Update CHANGELOG.md
 
 ## [0.1.0] - 2024-07-28
 

--- a/src/libraries/ContractLib.sol
+++ b/src/libraries/ContractLib.sol
@@ -221,6 +221,81 @@ library ContractLib {
         }
     }
 
+    /// delegatecall function + get return value
+    function delegatecall(
+        Contract c,
+        FunctionSignature sig,
+        bool hasOutput
+    )
+        internal
+        view
+        returns (bytes memory result)
+    {
+        assembly {
+            let ptr := mload(0x40)
+            mstore(ptr, sig)
+
+            let success := staticcall(gas(), c, ptr, 0x04, 0x00, 0x00)
+
+            if iszero(success) {
+                /// @dev bytes4(keccak256("UnableToCall()")) => 0x09108f6e
+                mstore(0x80, 0x09108f6e)
+                revert(0x9c, 0x04)
+            }
+
+            if eq(hasOutput, 0x1) {
+                let size := returndatasize()
+                mstore(ptr, size)
+                returndatacopy(add(ptr, 0x20), 0x0, size)
+                mstore(0x40, add(ptr, add(size, 0x20)))
+
+                result := ptr
+            }
+        }
+    }
+
+    /// delegatecall function + get return value + with input
+    function delegatecall(
+        Contract c,
+        FunctionSignature sig,
+        FunctionInput[] memory input,
+        bool hasOutput
+    )
+        internal
+        view
+        returns (bytes memory result)
+    {
+        assembly {
+            let inputLen := mload(input)
+            let ptr := mload(0x40)
+            mstore(ptr, sig)
+            let nextPtr := add(ptr, 0x04)
+
+            let i
+            for { i := 0 } lt(i, inputLen) { i := add(i, 0x1) } {
+                let multiplier := mul(i, 0x20)
+                mstore(add(nextPtr, multiplier), mload(add(input, add(multiplier, 0x20))))
+            }
+
+            let success := staticcall(gas(), c, ptr, add(0x04, mul(inputLen, 0x20)), 0x00, 0x00)
+
+            if iszero(success) {
+                /// @dev bytes4(keccak256("UnableToCall()")) => 0x09108f6e
+                mstore(0x80, 0x09108f6e)
+                revert(0x9c, 0x04)
+            }
+
+            if eq(hasOutput, 0x1) {
+                let size := returndatasize()
+                mstore(ptr, size)
+                returndatacopy(add(ptr, 0x20), 0x0, size)
+                mstore(0x40, add(ptr, add(size, 0x20)))
+
+                result := ptr
+            }
+        }
+    }
+
     function balance(Contract c) public view returns (uint256 result) {
         assembly {
             result := balance(c)

--- a/src/libraries/ContractLib.sol
+++ b/src/libraries/ContractLib.sol
@@ -26,11 +26,21 @@ library ContractLib {
         }
     }
 
-    /// @dev send ether + call function
-    function call(Contract c, uint256 amount, FunctionSignature sig) public {
+    /// @dev send ether + call function + get return value (optional)
+    function call(
+        Contract c,
+        uint256 amount,
+        FunctionSignature sig,
+        bool hasOutput
+    )
+        internal
+        returns (bytes memory output)
+    {
         assembly {
             let ptr := mload(0x40)
             mstore(ptr, sig)
+
+            let outPtr := add(output, 0x20)
 
             let success := call(gas(), c, amount, ptr, 0x04, 0x00, 0x00)
 
@@ -39,16 +49,36 @@ library ContractLib {
                 mstore(0x80, 0x09108f6e)
                 revert(0x9c, 0x04)
             }
+
+            if eq(hasOutput, 0x1) {
+                let size := returndatasize()
+                mstore(ptr, size)
+                returndatacopy(add(ptr, 0x20), 0x0, size)
+                mstore(0x40, add(ptr, add(size, 0x20)))
+
+                output := ptr
+            }
         }
     }
 
-    /// @dev send ether + call function + with input
-    function call(Contract c, uint256 amount, FunctionSignature sig, FunctionInput[] memory input) public {
+    /// @dev send ether + call function + get return value (optional) + with input
+    function call(
+        Contract c,
+        uint256 amount,
+        FunctionSignature sig,
+        FunctionInput[] memory input,
+        bool hasOutput
+    )
+        internal
+        returns (bytes memory output)
+    {
         assembly {
             let inputLen := mload(input)
             let ptr := mload(0x40)
             mstore(ptr, sig)
             let nextPtr := add(ptr, 0x04)
+
+            let outPtr := add(output, 0x20)
 
             let i
             for { i := 0 } lt(i, inputLen) { i := add(i, 0x1) } {
@@ -63,100 +93,34 @@ library ContractLib {
                 mstore(0x80, 0x09108f6e)
                 revert(0x9c, 0x04)
             }
-        }
-    }
 
-    /// @dev send ether + call function + get return value
-    function call(
-        Contract c,
-        uint256 amount,
-        FunctionSignature sig,
-        uint8 outLen
-    )
-        internal
-        returns (bytes32[] memory output)
-    {
-        output = new bytes32[](outLen);
+            if eq(hasOutput, 0x1) {
+                let size := returndatasize()
+                mstore(ptr, size)
+                returndatacopy(add(ptr, 0x20), 0x0, size)
+                mstore(0x40, add(ptr, add(size, 0x20)))
 
-        assembly {
-            let ptr := mload(0x40)
-            mstore(ptr, sig)
-
-            let outPtr := add(output, 0x20)
-
-            let success := call(gas(), c, amount, ptr, 0x04, outPtr, mul(outLen, 0x20))
-
-            if iszero(success) {
-                /// @dev bytes4(keccak256("UnableToCall()")) => 0x09108f6e
-                mstore(0x80, 0x09108f6e)
-                revert(0x9c, 0x04)
+                output := ptr
             }
         }
     }
 
-    /// @dev send ether + call function + get return value + with input
-    function call(
-        Contract c,
-        uint256 amount,
-        FunctionSignature sig,
-        FunctionInput[] memory input,
-        uint8 outLen
-    )
-        internal
-        returns (bytes32[] memory output)
-    {
-        output = new bytes32[](outLen);
-
-        assembly {
-            let inputLen := mload(input)
-            let ptr := mload(0x40)
-            mstore(ptr, sig)
-            let nextPtr := add(ptr, 0x04)
-
-            let outPtr := add(output, 0x20)
-
-            let i
-            for { i := 0 } lt(i, inputLen) { i := add(i, 0x1) } {
-                let multiplier := mul(i, 0x20)
-                mstore(add(nextPtr, multiplier), mload(add(input, add(multiplier, 0x20))))
-            }
-
-            let success := call(gas(), c, amount, ptr, add(0x04, mul(inputLen, 0x20)), outPtr, mul(outLen, 0x20))
-
-            if iszero(success) {
-                /// @dev bytes4(keccak256("UnableToCall()")) => 0x09108f6e
-                mstore(0x80, 0x09108f6e)
-                revert(0x9c, 0x04)
-            }
-        }
+    /// @dev call function + get return value (optional)
+    function call(Contract c, FunctionSignature sig, bool hasOutput) internal returns (bytes memory output) {
+        output = call(c, 0x0, sig, hasOutput);
     }
 
-    /// @dev call function
-    function call(Contract c, FunctionSignature sig) internal {
-        call(c, 0x0, sig);
-    }
-
-    /// @dev call function + with input
-    function call(Contract c, FunctionSignature sig, FunctionInput[] memory input) internal {
-        call(c, 0x0, sig, input);
-    }
-
-    /// @dev call function + get return value
-    function call(Contract c, FunctionSignature sig, uint8 outLen) internal returns (bytes32[] memory output) {
-        output = call(c, 0x0, sig, outLen);
-    }
-
-    /// @dev call function + get return value + with input
+    /// @dev call function + get return value (optional) + with input
     function call(
         Contract c,
         FunctionSignature sig,
         FunctionInput[] memory input,
-        uint8 outLen
+        bool hasOutput
     )
         internal
-        returns (bytes32[] memory output)
+        returns (bytes memory output)
     {
-        output = call(c, 0x0, sig, input, outLen);
+        output = call(c, 0x0, sig, input, hasOutput);
     }
 
     /// staticcall function + get return value

--- a/src/libraries/ContractLib.sol
+++ b/src/libraries/ContractLib.sol
@@ -159,6 +159,68 @@ library ContractLib {
         output = call(c, 0x0, sig, input, outLen);
     }
 
+    /// staticcall function + get return value
+    function staticcall(Contract c, FunctionSignature sig) internal view returns (bytes memory result) {
+        assembly {
+            let ptr := mload(0x40)
+            mstore(ptr, sig)
+
+            let success := staticcall(gas(), c, ptr, 0x04, 0x00, 0x00)
+
+            if iszero(success) {
+                /// @dev bytes4(keccak256("UnableToCall()")) => 0x09108f6e
+                mstore(0x80, 0x09108f6e)
+                revert(0x9c, 0x04)
+            }
+
+            let size := returndatasize()
+            mstore(ptr, size)
+            returndatacopy(add(ptr, 0x20), 0x0, size)
+            mstore(0x40, add(ptr, add(size, 0x20)))
+
+            result := ptr
+        }
+    }
+
+    /// staticcall function + get return value + with input
+    function staticcall(
+        Contract c,
+        FunctionSignature sig,
+        FunctionInput[] memory input
+    )
+        internal
+        view
+        returns (bytes memory result)
+    {
+        assembly {
+            let inputLen := mload(input)
+            let ptr := mload(0x40)
+            mstore(ptr, sig)
+            let nextPtr := add(ptr, 0x04)
+
+            let i
+            for { i := 0 } lt(i, inputLen) { i := add(i, 0x1) } {
+                let multiplier := mul(i, 0x20)
+                mstore(add(nextPtr, multiplier), mload(add(input, add(multiplier, 0x20))))
+            }
+
+            let success := staticcall(gas(), c, ptr, add(0x04, mul(inputLen, 0x20)), 0x00, 0x00)
+
+            if iszero(success) {
+                /// @dev bytes4(keccak256("UnableToCall()")) => 0x09108f6e
+                mstore(0x80, 0x09108f6e)
+                revert(0x9c, 0x04)
+            }
+
+            let size := returndatasize()
+            mstore(ptr, size)
+            returndatacopy(add(ptr, 0x20), 0x0, size)
+            mstore(0x40, add(ptr, add(size, 0x20)))
+
+            result := ptr
+        }
+    }
+
     function balance(Contract c) public view returns (uint256 result) {
         assembly {
             result := balance(c)

--- a/test/ContractLib.t.sol
+++ b/test/ContractLib.t.sol
@@ -2,72 +2,9 @@
 pragma solidity 0.8.26;
 
 import { Contract, ContractLib, FunctionInput, FunctionSignature } from "../src/libraries/ContractLib.sol";
+
+import { ExternalFunctions } from "./mocks/ExternalFunctions.sol";
 import { Test, console } from "forge-std/Test.sol";
-
-contract TestContract {
-    uint256 public x;
-    uint256 public y;
-    bytes32 public z;
-
-    function a() public payable {
-        x = x + 1;
-    }
-
-    function b(uint256 incCount) public payable {
-        y += incCount;
-    }
-
-    function c() public payable returns (uint256 result_1, bytes32 result_2) {
-        result_1 = 1024;
-        result_2 = "i know";
-    }
-
-    function d(uint256 incCount, bytes32 text) public payable returns (uint256 result_1, bytes32 result_2) {
-        result_1 = incCount;
-        result_2 = text;
-    }
-
-    function i() public {
-        z = "hey, there";
-    }
-
-    function j(uint256 num) public {
-        x = num;
-    }
-
-    function k() public pure returns (bytes32 result) {
-        result = "oui";
-    }
-
-    function l(uint256 num, bytes32 text) public returns (bool result, bytes32 ctx) {
-        x = num;
-        z = text;
-
-        result = true;
-        ctx = "this is result";
-    }
-
-    function o(bool change) public pure returns (string memory result_1, uint256[] memory result_2) {
-        if (change == true) {
-            uint256[] memory tmp = new uint256[](3);
-            tmp[0] = 1;
-            tmp[1] = 2;
-            tmp[2] = 3;
-            result_2 = tmp;
-        } else {
-            uint256[] memory tmp = new uint256[](3);
-            tmp[0] = 11;
-            tmp[1] = 22;
-            tmp[2] = 33;
-            result_2 = tmp;
-        }
-        result_1 = "hello there";
-    }
-
-    receive() external payable { }
-
-    fallback() external payable { }
-}
 
 /// @dev This is a contract that has no receive function and it is for error reverts.
 contract TestContract2 { }
@@ -75,8 +12,8 @@ contract TestContract2 { }
 contract ContractLibTest is Test {
     using ContractLib for address;
 
-    TestContract internal testContract;
-    TestContract2 internal testContract2;
+    ExternalFunctions internal testContract;
+    address internal testContract2 = vm.randomAddress();
 
     address internal caller = address(1);
 
@@ -96,9 +33,9 @@ contract ContractLibTest is Test {
     error NotContract();
 
     function setUp() public {
-        testContract = new TestContract();
-        testContract2 = new TestContract2();
+        testContract = new ExternalFunctions();
         vm.deal(caller, 1_000_000 ether);
+        vm.etch(testContract2, hex"60806040525f80fdfea164736f6c634300081a000a");
     }
 
     function test_Call_SendEther() public {

--- a/test/mocks/ExternalFunctions.sol
+++ b/test/mocks/ExternalFunctions.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.26;
+
+contract ExternalFunctions {
+    uint256 public x;
+    uint256 public y;
+    bytes32 public z;
+
+    function a() external payable {
+        x = x + 1;
+    }
+
+    function b(uint256 incCount) external payable {
+        y += incCount;
+    }
+
+    function c() external payable returns (uint256 result_1, bytes32 result_2) {
+        result_1 = 1024;
+        result_2 = "i know";
+    }
+
+    function d(uint256 incCount, bytes32 text) external payable returns (uint256 result_1, bytes32 result_2) {
+        result_1 = incCount;
+        result_2 = text;
+    }
+
+    function i() external {
+        z = "hey, there";
+    }
+
+    function j(uint256 num) external {
+        x = num;
+    }
+
+    function k() external pure returns (bytes32 result) {
+        result = "oui";
+    }
+
+    function l(uint256 num, bytes32 text) external returns (bool result, bytes32 ctx) {
+        x = num;
+        z = text;
+
+        result = true;
+        ctx = "this is result";
+    }
+
+    function o(bool change) external pure returns (string memory result_1, uint256[] memory result_2) {
+        if (change == true) {
+            uint256[] memory tmp = new uint256[](3);
+            tmp[0] = 1;
+            tmp[1] = 2;
+            tmp[2] = 3;
+            result_2 = tmp;
+        } else {
+            uint256[] memory tmp = new uint256[](3);
+            tmp[0] = 11;
+            tmp[1] = 22;
+            tmp[2] = 33;
+            result_2 = tmp;
+        }
+        result_1 = "hello there";
+    }
+
+    receive() external payable { }
+
+    fallback() external payable { }
+}


### PR DESCRIPTION
This PR introduces several updates to the `ContractLib`:

- **Features:**
  - 🚀 Implemented `delegatecall` & `staticcall` functionality in `ContractLib`.

- **Refactoring:**
  - 🔄 Merged various call functions within `ContractLib`.
  - 🛠️ Added a mock contract to facilitate testing.
  - 🧪 Implemented the mock contract in `ContractLib.t.sol`.

- **Testing:**
  - 🧪 Added test cases for `staticcall` in `ContractLib`.
  - ✅ Tested the newly implemented call functions.