### PR TITLE
Fix Slot Updates and Delegatecall in ContractLib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to this project will be documented in this file.
 - *(PointerLib)* Fix `update` function bug
 - *(EventLib)* Update anonymous emitters
 - *(ContractLib)* Remove redundant overwrite
+- *(ContractLibLogic)* Update wrong slots
+- *(ContractLib)* Update staticcall to delegatecall
 
 ### 🚜 Refactor
 
@@ -63,6 +65,9 @@ All notable changes to this project will be documented in this file.
 - *(ContractLib)* Update test cases
 - *(ContractLib)* Add staticcall test cases
 - *(ContractLib)* Test new call functions
+- *(ContractLib)* Add mock proxy and logic
+- *(ContractLib)* Add delegatecall test cases
+- *(ContractLib)* Add revert cases of delegatecall
 
 ### ⚙️ Miscellaneous Tasks
 
@@ -75,6 +80,9 @@ All notable changes to this project will be documented in this file.
 - Update CHANGELOG.md
 - Update Gasgnome.sol
 - Update CHANGELOG.md
+- Update CHANGELOG.md
+- *(ContractLibProxy)* Add logic slots
+- *(ContractLibProxy)* Add delegatecall with wrong function signature
 
 ## [0.1.0] - 2024-07-28
 

--- a/src/libraries/ContractLib.sol
+++ b/src/libraries/ContractLib.sol
@@ -186,20 +186,12 @@ library ContractLib {
     }
 
     /// delegatecall function + get return value
-    function delegatecall(
-        Contract c,
-        FunctionSignature sig,
-        bool hasOutput
-    )
-        internal
-        view
-        returns (bytes memory result)
-    {
+    function delegatecall(Contract c, FunctionSignature sig, bool hasOutput) internal returns (bytes memory result) {
         assembly {
             let ptr := mload(0x40)
             mstore(ptr, sig)
 
-            let success := staticcall(gas(), c, ptr, 0x04, 0x00, 0x00)
+            let success := delegatecall(gas(), c, ptr, 0x04, 0x00, 0x00)
 
             if iszero(success) {
                 /// @dev bytes4(keccak256("UnableToCall()")) => 0x09108f6e
@@ -226,7 +218,6 @@ library ContractLib {
         bool hasOutput
     )
         internal
-        view
         returns (bytes memory result)
     {
         assembly {
@@ -241,7 +232,7 @@ library ContractLib {
                 mstore(add(nextPtr, multiplier), mload(add(input, add(multiplier, 0x20))))
             }
 
-            let success := staticcall(gas(), c, ptr, add(0x04, mul(inputLen, 0x20)), 0x00, 0x00)
+            let success := delegatecall(gas(), c, ptr, add(0x04, mul(inputLen, 0x20)), 0x00, 0x00)
 
             if iszero(success) {
                 /// @dev bytes4(keccak256("UnableToCall()")) => 0x09108f6e

--- a/test/ContractLib.t.sol
+++ b/test/ContractLib.t.sol
@@ -3,16 +3,18 @@ pragma solidity 0.8.26;
 
 import { Contract, ContractLib, FunctionInput, FunctionSignature } from "../src/libraries/ContractLib.sol";
 
+import { ContractLibLogic } from "./mocks/ContractLibLogic.sol";
+import { ContractLibProxy } from "./mocks/ContractLibProxy.sol";
 import { ExternalFunctions } from "./mocks/ExternalFunctions.sol";
-import { Test, console } from "forge-std/Test.sol";
 
-/// @dev This is a contract that has no receive function and it is for error reverts.
-contract TestContract2 { }
+import { Test, console } from "forge-std/Test.sol";
 
 contract ContractLibTest is Test {
     using ContractLib for address;
 
     ExternalFunctions internal testContract;
+    ContractLibProxy internal contractLibProxy;
+    ContractLibLogic internal contractLibLogic;
     address internal testContract2 = vm.randomAddress();
 
     address internal caller = address(1);
@@ -34,6 +36,8 @@ contract ContractLibTest is Test {
 
     function setUp() public {
         testContract = new ExternalFunctions();
+        contractLibLogic = new ContractLibLogic();
+        contractLibProxy = new ContractLibProxy(address(contractLibLogic));
         vm.deal(caller, 1_000_000 ether);
         vm.etch(testContract2, hex"60806040525f80fdfea164736f6c634300081a000a");
     }
@@ -162,6 +166,42 @@ contract ContractLibTest is Test {
         assertEq(1, result_2[0]);
         assertEq(2, result_2[1]);
         assertEq(3, result_2[2]);
+    }
+
+    function test_Delegatecall_WithoutInputAndWithoutReturnValue() public {
+        contractLibProxy.delegatecallWithoutInputAndWithoutReturnValue();
+
+        uint256 expected = 1024;
+        uint256 numberOne = contractLibProxy.getNumberOne();
+
+        assertEq(expected, numberOne);
+    }
+
+    function test_Delegatecall_WithoutInputAndWithReturnValue() public {
+        contractLibProxy.delegatecallWithoutInputAndWithReturnValue();
+
+        uint256 expected = 2048;
+        uint256 numberTwo = contractLibProxy.getNumberTwo();
+
+        assertEq(expected, numberTwo);
+    }
+
+    function test_Delegatecall_WithInputAndWithoutReturnValue() public {
+        contractLibProxy.delegatecallWithInputAndWithoutReturnValue();
+
+        uint256 expected = 4096;
+        uint256 numberThree = contractLibProxy.getNumberThree();
+
+        assertEq(expected, numberThree);
+    }
+
+    function test_Delegatecall_WithInputAndWithReturnValue() public {
+        contractLibProxy.delegatecallWithInputAndWithReturnValue();
+
+        uint256 expected = 8192;
+        uint256 numberFour = contractLibProxy.getNumberFour();
+
+        assertEq(expected, numberFour);
     }
 
     function test_RevertWhen_NoReceiveFunctionFound_Call_SendEther() public {

--- a/test/ContractLib.t.sol
+++ b/test/ContractLib.t.sol
@@ -259,6 +259,20 @@ contract ContractLibTest is Test {
         c.staticcall(functionOSig, fi);
     }
 
+    function test_RevertIf_MalformedFunctionSignature_DelegateCall_DelegatecallWrongFunctionSignatureWithoutInput()
+        public
+    {
+        vm.expectRevert(UnableToCall.selector);
+        contractLibProxy.delegatecallWrongFunctionSignatureWithoutInput();
+    }
+
+    function test_RevertIf_MalformedFunctionSignature_DelegateCall_DelegatecallWrongFunctionSignatureWithInput()
+        public
+    {
+        vm.expectRevert(UnableToCall.selector);
+        contractLibProxy.delegatecallWrongFunctionSignatureWithInput();
+    }
+
     function test_RevertWhen_AddressIsNotContract_ToContract() public {
         vm.expectRevert(NotContract.selector);
         address(address(1)).toContract();

--- a/test/mocks/ContractLibLogic.sol
+++ b/test/mocks/ContractLibLogic.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.26;
+
+contract ContractLibLogic {
+    bytes32 internal numberOneSlot = bytes32(keccak256("number.1"));
+    bytes32 internal numberTwoSlot = bytes32(keccak256("number.2"));
+    bytes32 internal numberThreeSlot = bytes32(keccak256("number.3"));
+    bytes32 internal numberFourSlot = bytes32(keccak256("number.4"));
+
+    function setNumberOne() public {
+        assembly {
+            sstore(numberOneSlot.slot, 1024)
+        }
+    }
+
+    function setNumberTwo() public returns (uint256 newValue) {
+        assembly {
+            newValue := 2048
+            sstore(numberTwoSlot.slot, 2048)
+        }
+    }
+
+    function setNumberThree(uint256 num) public {
+        assembly {
+            sstore(numberTwoSlot.slot, num)
+        }
+    }
+
+    function setNumberFour(uint256 num) public returns (uint256 newValue) {
+        assembly {
+            newValue := num
+            sstore(numberTwoSlot.slot, newValue)
+        }
+    }
+}

--- a/test/mocks/ContractLibLogic.sol
+++ b/test/mocks/ContractLibLogic.sol
@@ -16,20 +16,20 @@ contract ContractLibLogic {
     function setNumberTwo() public returns (uint256 newValue) {
         assembly {
             newValue := 2048
-            sstore(numberTwoSlot.slot, 2048)
+            sstore(numberTwoSlot.slot, newValue)
         }
     }
 
     function setNumberThree(uint256 num) public {
         assembly {
-            sstore(numberTwoSlot.slot, num)
+            sstore(numberThreeSlot.slot, num)
         }
     }
 
     function setNumberFour(uint256 num) public returns (uint256 newValue) {
         assembly {
             newValue := num
-            sstore(numberTwoSlot.slot, newValue)
+            sstore(numberFourSlot.slot, newValue)
         }
     }
 }

--- a/test/mocks/ContractLibProxy.sol
+++ b/test/mocks/ContractLibProxy.sol
@@ -4,6 +4,10 @@ pragma solidity 0.8.26;
 import { Contract, ContractLib, FunctionInput, FunctionSignature } from "../../src/libraries/ContractLib.sol";
 
 contract ContractLibProxy {
+    bytes32 internal numberOneSlot = bytes32(keccak256("number.1"));
+    bytes32 internal numberTwoSlot = bytes32(keccak256("number.2"));
+    bytes32 internal numberThreeSlot = bytes32(keccak256("number.3"));
+    bytes32 internal numberFourSlot = bytes32(keccak256("number.4"));
     bytes32 internal implementationSlot = bytes32(keccak256("implementation"));
 
     constructor(address _implementation) {
@@ -18,21 +22,45 @@ contract ContractLibProxy {
         }
     }
 
-    function delegatecallWithoutInputAndWithoutReturnValue() public view {
+    function getNumberOne() public view returns (uint256 result) {
+        assembly {
+            result := sload(numberOneSlot.slot)
+        }
+    }
+
+    function getNumberTwo() public view returns (uint256 result) {
+        assembly {
+            result := sload(numberTwoSlot.slot)
+        }
+    }
+
+    function getNumberThree() public view returns (uint256 result) {
+        assembly {
+            result := sload(numberThreeSlot.slot)
+        }
+    }
+
+    function getNumberFour() public view returns (uint256 result) {
+        assembly {
+            result := sload(numberFourSlot.slot)
+        }
+    }
+
+    function delegatecallWithoutInputAndWithoutReturnValue() public {
         Contract c = getImplementationContract();
         FunctionSignature fs = FunctionSignature.wrap(bytes4(keccak256("setNumberOne()")));
 
         c.delegatecall(fs, false);
     }
 
-    function delegatecallWithoutInputAndWithReturnValue() public view returns (bytes memory result) {
+    function delegatecallWithoutInputAndWithReturnValue() public returns (bytes memory result) {
         Contract c = getImplementationContract();
         FunctionSignature fs = FunctionSignature.wrap(bytes4(keccak256("setNumberTwo()")));
 
         result = c.delegatecall(fs, true);
     }
 
-    function delegatecallWithInputAndWithoutReturnValue() public view {
+    function delegatecallWithInputAndWithoutReturnValue() public {
         Contract c = getImplementationContract();
         FunctionSignature fs = FunctionSignature.wrap(bytes4(keccak256("setNumberThree(uint256)")));
         FunctionInput[] memory fi = new FunctionInput[](1);
@@ -41,7 +69,7 @@ contract ContractLibProxy {
         c.delegatecall(fs, fi, false);
     }
 
-    function delegatecallWithInputAndWithReturnValue() public view returns (bytes memory result) {
+    function delegatecallWithInputAndWithReturnValue() public returns (bytes memory result) {
         Contract c = getImplementationContract();
         FunctionSignature fs = FunctionSignature.wrap(bytes4(keccak256("setNumberFour(uint256)")));
         FunctionInput[] memory fi = new FunctionInput[](1);

--- a/test/mocks/ContractLibProxy.sol
+++ b/test/mocks/ContractLibProxy.sol
@@ -77,4 +77,20 @@ contract ContractLibProxy {
 
         result = c.delegatecall(fs, fi, true);
     }
+
+    function delegatecallWrongFunctionSignatureWithoutInput() public {
+        Contract c = getImplementationContract();
+        FunctionSignature fs = FunctionSignature.wrap(bytes4(keccak256("setNumberOneA()")));
+
+        c.delegatecall(fs, false);
+    }
+
+    function delegatecallWrongFunctionSignatureWithInput() public {
+        Contract c = getImplementationContract();
+        FunctionSignature fs = FunctionSignature.wrap(bytes4(keccak256("setNumberThreeA(uint256)")));
+        FunctionInput[] memory fi = new FunctionInput[](1);
+        fi[0] = FunctionInput.wrap(bytes32(uint256(4096)));
+
+        c.delegatecall(fs, fi, false);
+    }
 }

--- a/test/mocks/ContractLibProxy.sol
+++ b/test/mocks/ContractLibProxy.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.26;
+
+import { Contract, ContractLib, FunctionInput, FunctionSignature } from "../../src/libraries/ContractLib.sol";
+
+contract ContractLibProxy {
+    bytes32 internal implementationSlot = bytes32(keccak256("implementation"));
+
+    constructor(address _implementation) {
+        assembly {
+            sstore(implementationSlot.slot, _implementation)
+        }
+    }
+
+    function getImplementationContract() public view returns (Contract result) {
+        assembly {
+            result := sload(implementationSlot.slot)
+        }
+    }
+
+    function delegatecallWithoutInputAndWithoutReturnValue() public view {
+        Contract c = getImplementationContract();
+        FunctionSignature fs = FunctionSignature.wrap(bytes4(keccak256("setNumberOne()")));
+
+        c.delegatecall(fs, false);
+    }
+
+    function delegatecallWithoutInputAndWithReturnValue() public view returns (bytes memory result) {
+        Contract c = getImplementationContract();
+        FunctionSignature fs = FunctionSignature.wrap(bytes4(keccak256("setNumberTwo()")));
+
+        result = c.delegatecall(fs, true);
+    }
+
+    function delegatecallWithInputAndWithoutReturnValue() public view {
+        Contract c = getImplementationContract();
+        FunctionSignature fs = FunctionSignature.wrap(bytes4(keccak256("setNumberThree(uint256)")));
+        FunctionInput[] memory fi = new FunctionInput[](1);
+        fi[0] = FunctionInput.wrap(bytes32(uint256(4096)));
+
+        c.delegatecall(fs, fi, false);
+    }
+
+    function delegatecallWithInputAndWithReturnValue() public view returns (bytes memory result) {
+        Contract c = getImplementationContract();
+        FunctionSignature fs = FunctionSignature.wrap(bytes4(keccak256("setNumberFour(uint256)")));
+        FunctionInput[] memory fi = new FunctionInput[](1);
+        fi[0] = FunctionInput.wrap(bytes32(uint256(8192)));
+
+        result = c.delegatecall(fs, fi, true);
+    }
+}


### PR DESCRIPTION
This PR addresses several issues and adds new test cases to the `ContractLib`:

- **Bug Fixes:**
  - 🐛 Updated wrong slots in `ContractLibLogic`.
  - 🐛 Changed `staticcall` to `delegatecall` in `ContractLib`.

- **Testing:**
  - 🧪 Added test cases for `delegatecall` in `ContractLib`.
  - 🧪 Included revert cases for `delegatecall`.

- **Miscellaneous Tasks:**
  - ⚙️ Added logic slots in `ContractLibProxy`.
  - ⚙️ Implemented `delegatecall` with incorrect function signature in `ContractLibProxy`.

These changes fix critical issues, improve the reliability of delegatecall operations, and expand the testing suite for better coverage.